### PR TITLE
Go to solar energy folder

### DIFF
--- a/solar-energy/.github/workflows/deploy-hostinger-ftp.yml
+++ b/solar-energy/.github/workflows/deploy-hostinger-ftp.yml
@@ -1,0 +1,38 @@
+name: Deploy to Hostinger via FTP
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+        working-directory: solar-energy
+
+      - name: Build
+        run: npm run build
+        working-directory: solar-energy
+
+      - name: Deploy via FTP to Hostinger
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        with:
+          server: ${{ secrets.FTP_SERVER }}
+          username: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          protocol: ftps
+          local-dir: solar-energy/dist/
+          server-dir: public_html/
+          dry-run: false
+          log-level: minimal


### PR DESCRIPTION
Add a GitHub Actions workflow to deploy the built `dist/` folder to Hostinger via FTP.

This workflow enables automatic deployment to Hostinger's `public_html/` directory whenever changes are pushed to the `main` branch, using FTP credentials stored as GitHub Secrets.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a9e75a8-c330-4093-b13d-9fb786863642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5a9e75a8-c330-4093-b13d-9fb786863642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

